### PR TITLE
added layout for notice_categories

### DIFF
--- a/themes/nav-community-v2/layouts/notice_categories/list.html
+++ b/themes/nav-community-v2/layouts/notice_categories/list.html
@@ -28,7 +28,7 @@
                                   <li><i class="fa fa-user-o"></i>{{ .Params.author }}</li>
                                   <li>
                                     <i class="fa fa-calendar"></i>
-                                      {{ dateFormat "2 Jan 2006" .Params.date }}
+                                      {{ dateFormat "2 Jan 2006" .Date }}
                                   </li>
                               </ul>
                               <ul class="blog-author-name">

--- a/themes/nav-community-v2/layouts/notice_categories/list.html
+++ b/themes/nav-community-v2/layouts/notice_categories/list.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+{{ partial "head.html" . }}
+
+<body data-spy="scroll" data-target="#header-menu">
+
+  {{ partial "header.html" .  }}
+
+  {{ partial "notices_header.html" .  }}
+
+<div class="appix-blog-content section-ptb-2">
+    <div class="container">
+      <div class="row">
+          <div class="col-sm-12 col-md-8">
+            {{ $list := (.Data.Pages) }}
+            {{ range $index, $element := .Data.Pages }}
+              <div class="blog-item">
+                  <a href="{{ .URL }}">
+                    <div class="blog-image" style="background-image:url({{ .Params.feature_image }});">
+                      <div class="item-overlay"></div>
+                    </div>
+                  </a>
+                  <div class="blog-details">
+                              <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+                              <ul class="blog-author-name">
+                                  <li><i class="fa fa-user-o"></i>{{ .Params.author }}</li>
+                                  <li>
+                                    <i class="fa fa-calendar"></i>
+                                      {{ dateFormat "2 Jan 2006" .Params.date }}
+                                  </li>
+                              </ul>
+                              <ul class="blog-author-name">
+                                  {{ range .Params.categories }}
+                                  <li><i class="fa fa-folder-open-o"></i>{{.}} </li>
+                                  {{end}}
+                              </ul>
+                              <div class="blog-excerpt">
+                                {{ if .Summary }}
+                                  {{.Summary}}
+                                {{ else }}
+                                  {{.Content}}
+                                {{ end }}
+                              </div>
+                              <div style="    
+                                display: flex;
+                                justify-content: space-between;
+                                 align-items: center;
+                                margin: 10px 0px 10px;">
+                              <a href="{{ .URL }}" class="round-btn gradient-btn" style="box-shadow: none;">Read More 
+                                    <img src=/images/icons/rightward-arrow.svg class="btn-img"> </span></a>
+                              <!-- <div class="read-more">
+                                  <div class="themeix-button-group">
+                                      <a href="{{ .URL }}" class="themeix-btn themeix-danger">read more</a>
+                                  </div>
+                              </div> -->
+                              {{ partial "social_share.html" .  }}
+                            </div>
+                          </div>
+                </div>
+
+            {{ end }}
+            </div>
+            <div class="col-md-3 col-sm-12 col-md-offset-1">
+                <div class="sidebar">
+                    <div class="widget">
+                        <h3 class="widget-title">Notice Categories</h3>
+                        <ul>
+                          {{ range first 10 .Site.Taxonomies.notice_categories.ByCount }}
+                            {{ $filter := replace .Name "-" " " }}
+                              <li class="cat-item" ><a href="/notice_categories/{{ .Name | urlize }}">{{ $filter }}</a> </li>
+                          {{ end }}
+                        </ul>
+                    </div>
+                    <div class="widget custom recent-posts">
+                        <h3 class="widget-title">Recent Notices</h3>
+                        <ul>
+                            {{ range .Site.Pages }}
+                                {{if (eq .Type "notices") }}
+                                  {{ if (ne .Title "Notices")}}
+                                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                                  {{ end }}
+                                {{ end }}
+                            {{ end }}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{ partial "footer.html" . }}
+
+</body>
+</html>


### PR DESCRIPTION
Adds a layout for the `notice_categories` pages.
They were defaulting to the default `_lists` partial which was empty.

Current: https://navcoin.org/notice_categories/general-notices
Fix: https://deploy-preview-110--navcoin.netlify.com/notice_categories/general-notices