### PR TITLE
Removing Cfinex as a supported exchange.

### DIFF
--- a/content/buy-navcoin/index.en.md
+++ b/content/buy-navcoin/index.en.md
@@ -73,12 +73,6 @@ newTab="true"
          text="NZD Direct Buy/Sell"
          linkUrl="https://www.bitprime.co.nz/product/navcoin-nav"
      >}}
-    {{< exchange
-        titleText="Cfinex"
-        imgSrc="/images/buy-navcoin/buy-cfinex.png"
-        text="Multi Exchange Platform"
-        linkUrl="https://cfinex.com/#NAV-BTC"
-    >}}
    {{< exchange
         titleText="Bisq"
         imgSrc="/images/buy-navcoin/buy-bisq.png"

--- a/content/buy-navcoin/index.es.md
+++ b/content/buy-navcoin/index.es.md
@@ -44,12 +44,6 @@ newTab="true"
         linkUrl="https://www.cryptopia.co.nz/Exchange/?market=NAV_BTC"
     >}}
     {{< exchange
-        titleText="Cfinex"
-        imgSrc="/images/buy-navcoin/buy-cfinex.png"
-        text="Multi Exchange Platform"
-        linkUrl="https://cfinex.com/#NAV-BTC"
-    >}}
-    {{< exchange
         titleText="Litebit"
         imgSrc="/images/buy-navcoin/buy-litebit.png"
         text="Euro Direct Purchase"


### PR DESCRIPTION
Resolves issue #111, by removing Cfinex as a listed exchange on the `Buy NavCoin` page. 