### PR TITLE
Language files for notices require inclusion.

### DIFF
--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.es.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.es.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.it.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.it.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.jp.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.jp.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.kr.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.kr.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.ru.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.ru.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-09-12-navcoin-core-purple-zebra.zh.md
+++ b/content/notices/2019-09-12-navcoin-core-purple-zebra.zh.md
@@ -1,0 +1,55 @@
+---
+layout: notices
+title: NavCoin Core 4.7.0 - Purple Zebra
+author: Craig MacGregor
+date: '2019-09-12T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.0.png
+notice_categories:
+  - General Notices
+---
+Purple Zebra is the culmination of the last few months of work on NavCoin Core and includes 40 closed pull requests, many new features and important security updates & stability fixes. Due to the security patches, upgrading to Purple Zebra should be considered mandatory and performed as soon as possible, especially if you are staking.
+<!--more-->
+
+
+### Added password prompt for CFund dialogs
+
+<[Pull Request 474](https://github.com/navcoin/navcoin-core/pull/474)>
+<[Commit aa4bbaa](https://github.com/navcoin/navcoin-core/commit/aa4bbaaf7a82600775065f6bab894f78583b9784)>
+
+Peviously you would have to unlock the wallet via the console or debug window before it was possible to create a proposal or payment request through the graphical interface. Now there is a dialog to unlock the wallet while using the Community Fund GUI.
+
+
+### Use of the CoinsDB for the Community Fund
+
+<[Pull Request 487](https://github.com/navcoin/navcoin-core/pull/487)>
+<[Commit a8f425b](https://github.com/navcoin/navcoin-core/commit/a8f425b9bd86147693c1e79427c39876425ac7cf)>
+
+Previously the community fund data was stored in a seperate local database to the rest of the coin data. The data has now been migrated to be part of the CoinsDB which should increase performance and mitigate the data consistency issues that some users were experiencing.
+
+
+### Added error log tab in debug window
+
+<[Pull Request 466](https://github.com/navcoin/navcoin-core/pull/466)>
+<[Commit bed76b9](https://github.com/navcoin/navcoin-core/commit/bed76b917b6590148a371d5a3d86d2a534ef1f3b)>
+
+You can now see errors which are logged to the debug.log file in the debug window of navcoin-qt. Users no longer have to manually read or search the debug.log via command line to find error messages.
+
+### Added new FIAT currencies and enabled auto price update
+
+<[Pull Request 469](https://github.com/navcoin/navcoin-core/pull/469)>
+<[Commit 5ee24af](https://github.com/navcoin/navcoin-core/commit/5ee24afd29937cd7c12d538313783671318d1c87)>
+
+30 Fiat can now be configured as the display units through of navcoin-qt. The issue causing the sockets polling for exchange rates not to close correctly has also been resolved which prevents the wallet from eventually crashing.
+
+### Added new progress ui for sync
+
+<[Pull Request 526](https://github.com/navcoin/navcoin-core/pull/526)>
+<[Commit 42769b2](https://github.com/navcoin/navcoin-core/commit/42769b2352f1a33e5b4f8c2971e787b22b00ecb4)>
+
+When the wallet starts and detects it is still catching up to the latest block a progress overlay will be presented to the user. The user can close the overlay but it is now clearer that the wallet is still syncing and the balances will be incorrect until syncing finishes.
+
+### More Information
+
+For the full release notes please visit the [Purple Zebra Release on GitHub](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.0).
+
+To download the NavCoin Purple Zebra please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.es.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.es.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.it.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.it.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.jp.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.jp.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.kr.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.kr.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.ru.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.ru.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-10-29-navcoin-core-4.7.1.zh.md
+++ b/content/notices/2019-10-29-navcoin-core-4.7.1.zh.md
@@ -1,0 +1,53 @@
+---
+layout: notices
+title: NavCoin Core 4.7.1 - Community Fund Nullified Entry Patch
+author: Craig MacGregor
+date: '2019-10-29T10:38:29+12:00'
+feature_image: /images/uploads/navcoin-core-4.7.1-cfund-patch.png
+notice_categories:
+  - General Notices
+  - Patch Release
+---
+This patch fixes a bug where a cfund database entry that was previously deleted is still persisting, preventing future writes of the entry. This can happen in a scenario where a proposal is included in a block which is invalidated (because of a reorganization) which is then included in a new block as part of the new longest chain.
+<!--more-->
+This fix is the main purpose of the 4.7.1 patch release, while preparing this bugfix there were several other PR's merged which are also included in this release.
+
+### Full List of Merged Pull Requests
+
+- Updated some NULL -> nullptr <[Pull Request 509](https://github.com/navcoin/navcoin-core/pull/509)> <[Commit 40eac7ab](https://github.com/navcoin/navcoin-core/commit/58e38079d7d854a6b02ebb228f06244140eac7ab)> 
+
+- Replaced all BOOST_FOREACH calls with new for() syntax (c++11) <[Pull Request 525](https://github.com/navcoin/navcoin-core/pull/525)> <[Commit 8ed8cf87](https://github.com/navcoin/navcoin-core/commit/2e6aa1b3e598d3a443343c480bdbf6b88ed8cf87)> 
+
+-  Updated the custom 'change' address to be a persistent setting #527 <[Pull Request 527](https://github.com/navcoin/navcoin-core/pull/527)> <[Commit b2921285](https://github.com/navcoin/navcoin-core/commit/74def82624ff9bb4598762186598d2bab2921285)>
+
+- Added new -allindex option <[Pull Request 546](https://github.com/navcoin/navcoin-core/pull/546)> <[Commit e1870814](https://github.com/navcoin/navcoin-core/commit/083e790aed0120dd271a648d87948e5ae1870814)>
+
+- Replaced Q_FOREACH with for()> from c++11 standard <[Pull Request 554](https://github.com/navcoin/navcoin-core/pull/554)> <[Commit 82523147](https://github.com/navcoin/navcoin-core/commit/0a8c872a60169de4f6b57b83dab9b39382523147)>
+
+- Set pindexDelete to nullptr on intialize <[Pull Request 560](https://github.com/navcoin/navcoin-core/pull/560)> <[Commit 762c3ffd](https://github.com/navcoin/navcoin-core/commit/64f8cd453f4bdda04f4a718cb026d8a8762c3ffd)> 
+
+- Fixed some gitignore permissions and added new file to main gitignore <[Pull Request 561](https://github.com/navcoin/navcoin-core/pull/561)> <[Commit 130ddf4a](https://github.com/navcoin/navcoin-core/commit/70276dba0515a133a47c081041092efa130ddf4a)>
+
+- Updated includes syntax based on discussion on #503 <[Pull Request 566](https://github.com/navcoin/navcoin-core/pull/566)> <[Commit 6de5f909](https://github.com/navcoin/navcoin-core/commit/556250920fef9dc3eddd28996329ba316de5f909)>
+
+- Sort available coins for staking by coin age descending <[Pull Request 578](https://github.com/navcoin/navcoin-core/pull/578)> <[Commit c464383b](https://github.com/navcoin/navcoin-core/commit/da5377e89a25cfa54a52768393630134c464383b)>
+
+- Add support for raw script addresses <[Pull Request 587](https://github.com/navcoin/navcoin-core/pull/587)> <[Commit ff6f543e](https://github.com/navcoin/navcoin-core/commit/49f74084cf9eed8d8e7c46707d836b82ff6f543e)>
+
+- Updated depends to use winssl for windows and darwinssl for osx <[Pull Request 603](https://github.com/navcoin/navcoin-core/pull/603)> <[Commit f755e298](https://github.com/navcoin/navcoin-core/commit/6fe0683ba99ce912da4d9181094ab4baf755e298)>
+
+- Staking reward setup GUI <[Pull Request 605](https://github.com/navcoin/navcoin-core/pull/605)> <[Commit 5e0af830](https://github.com/navcoin/navcoin-core/commit/0b8cb5dd81186fcd54860fe7c25f2cac5e0af830)>
+
+- Fixed error.log loading in Debug Window (Windows) <[Pull Request 611](https://github.com/navcoin/navcoin-core/pull/611)> <[Commit 30401b32](https://github.com/navcoin/navcoin-core/commit/f7b1c6304200052418c66e8f242ddf8c30401b32)>
+
+- Fix random RPC tests failing <[Pull Request 612](https://github.com/navcoin/navcoin-core/pull/612)> <[Commit d5cfa467](https://github.com/navcoin/navcoin-core/commit/902970adfdd5ce0e54e54bfa7545edfad5cfa467)>
+
+- Patch for staking redirect gui <[Pull Request 614](https://github.com/navcoin/navcoin-core/pull/614)> <[Commit 80323b33](https://github.com/navcoin/navcoin-core/commit/856d57a8f944ed3382d7001a3e9a1bfd80323b33)>
+
+- Bump version number <[Pull Request 615](https://github.com/navcoin/navcoin-core/pull/615)> <[Commit 9e84d40a](https://github.com/navcoin/navcoin-core/commit/662163ad8f73081d2d6145938571ca809e84d40a)>
+
+### More Information
+
+For the full release notes please visit the [Community Fund Nullified Entry Patch](https://github.com/NAVCoin/navcoin-core/releases/tag/4.7.1).
+
+To download the NavCoin Core 4.7.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.es.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.es.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.it.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.it.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.jp.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.jp.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.kr.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.kr.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.ru.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.ru.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.zh.md
+++ b/content/notices/2019-12-19-navcoin-core-4-7-2-community-fund-stability-patches.zh.md
@@ -1,0 +1,77 @@
+---
+layout: notices
+title: NavCoin Core 4.7.2 - Community Fund Stability Patches
+author: Craig MacGregor
+date: '2019-12-19T14:17:04+13:00'
+feature_image: /images/uploads/navcoin-template-2-.png
+notice_categories:
+  - General Notices
+---
+This patch fixes various issues which were investigated and identified as part of the community fund stability review undertaken by the NavCoin Core developers. It considered a mandatory update due to the included stability patches and will require a reindex or full resynchronisation of the blockchain to take effect. Please read the full release notes for further instruction.
+<!--more-->
+## Fix for Verify Chain
+
+<[Pull Request 634](https://github.com/navcoin/navcoin-core/pull/634)>
+<[Commit 049978e](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8)>
+
+This patch fixes [Issue 630](https://github.com/navcoin/navcoin-core/issues/630) and introduces several important changes.
+
+* New RPC command `getcfunddbstatehash` covered by functional test `cfunddb-statehash.py`
+* New state for payment requests `6` when those are paid.
+* The payment request parameter paidOnBlock is substituted by `stateChangedOnBlock` when state is `6`
+* New structure for storing the state history of CFundDB entries. Those are stored in a map associating blockhash and state, allowing to directly revert state transitions when reorganizations are seen.
+* `verifychain` now checks for the consistency of the CFundDB state hash when level 4 is specified.
+
+### IMPORTANT
+
+This set of changes will require older clients to reindex on launch, keeping the node offline for some hours at best. In order to reduce downtime, node operators can proceed as follows if needed:
+
+* Close node with old version.
+* `mkdir /tmp/reindexdata; cp -rf <data_folder>/blocks /tmp/reindexdata/; cp -rf <data_folder>/chainstate /tmp/reindexdata/`
+* Reopen node with old version. It will be again online
+* Launch in parallel a second instance of the node, this time using the new version with the parameters `-reindex -datadir=/tmp/reindexdata/`
+* Once the reindex finishes, close both nodes and copy back the reindexed data.
+* `rm -rf <data_folder>/blocks <data_folder>/chainstate; cp -rf /tmp/reindexdata/* <data_folder>`
+* Relaunch new version of the node.
+
+## CFundDB extra log and ensure read before modify
+
+<[Pull Request 622](https://github.com/navcoin/navcoin-core/pull/622)>
+<[Commit 37fa72e](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b)>
+
+This PR adds extra log for all the modifications of the CFundDB and ensures entries are read in the memory cache before being modified.
+
+## Restart testnet
+
+<[Pull Request 628](https://github.com/navcoin/navcoin-core/pull/628)>
+<[Commit b8ed018](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879)>
+
+This pull request starts a new NavCoin testnet. If you're running a testnet node you will need to will need to wipe your testnet data directory and connect to the new testnet nodes. A list of some of the testnet nodes operated by NavCoin Core developers can be found on [Issue 626](https://github.com/navcoin/navcoin-core/issues/626). If you need testnet coins or want to be added to the list of nodes, please comment on the issue or join the #dev-testnet channel in [Discord](https://discord.gg/y4Vu9jw).
+
+## Full list of Merged PRs
+
+* [`Pull Request 652`](https://github.com/navcoin/navcoin-core/pull/652) [`Commit 0cde809`](https://github.com/navcoin/navcoin-core/commit/0cde80954fd2bdca1859c0e90dfcc3243dba6c61) Remove new version popup
+* [`Pull Request 651`](https://github.com/navcoin/navcoin-core/pull/651) [`Commit 95b524e`](https://github.com/navcoin/navcoin-core/commit/95b524eefbfb87190a9038397d6c6a2c8ea081c9) Update translations
+* [`Pull Request 648`](https://github.com/navcoin/navcoin-core/pull/648) [`Commit 09f0531`](https://github.com/navcoin/navcoin-core/commit/09f053152761aa254dae27a9da3e338e2e31e671) Update QT strings
+* [`Pull Request 647`](https://github.com/navcoin/navcoin-core/pull/647) [`Commit 0eafc3b`](https://github.com/navcoin/navcoin-core/commit/0eafc3b404503c985993a7069bc8cb160100911d) Reactivate CFund
+* [`Pull Request 641`](https://github.com/navcoin/navcoin-core/pull/641) [`Commit 494d4e2`](https://github.com/navcoin/navcoin-core/commit/494d4e2d598ad114c407d609d7b8141e4ab54f50) Add extra stats to getblock
+* [`Pull Request 634`](https://github.com/navcoin/navcoin-core/pull/634) [`Commit 049978e`](https://github.com/navcoin/navcoin-core/commit/049978e246de960370f629fa38a6509fad0cf5c8) Fix for verifychain
+* [`Pull Request 644`](https://github.com/navcoin/navcoin-core/pull/644) [`Commit 5d59483`](https://github.com/navcoin/navcoin-core/commit/5d59483c50d985d3053299febe941dcfb447be46) Adds proposalHash to the RPC getpaymentrequest
+* [`Pull Request 643`](https://github.com/navcoin/navcoin-core/pull/643) [`Commit d501c89`](https://github.com/navcoin/navcoin-core/commit/d501c89ea412760de2074d8706fc1684d42d1445) CPaymentRequest fields incorrect in diff
+* [`Pull Request 638`](https://github.com/navcoin/navcoin-core/pull/638) [`Commit 8131b42`](https://github.com/navcoin/navcoin-core/commit/8131b4236054c5ee57e253ce75dc77a9992a6bed) Fixed freezing GUI on reindex
+* [`Pull Request 632`](https://github.com/navcoin/navcoin-core/pull/632) [`Commit 2ad3391`](https://github.com/navcoin/navcoin-core/commit/2ad3391e5195720af2d288f923081c24df023d99) Fix reference to chain tip
+* [`Pull Request 629`](https://github.com/navcoin/navcoin-core/pull/629) [`Commit 2a6c64f`](https://github.com/navcoin/navcoin-core/commit/2a6c64f87858d3452b9b830a0853e993379449d6) Seed nodes
+* [`Pull Request 637`](https://github.com/navcoin/navcoin-core/pull/637) [`Commit ad883cd`](https://github.com/navcoin/navcoin-core/commit/ad883cdfa1a1e478f6db30beb41511e97a37bb28) Set DEFAULT_SCRIPTCHECK_THREADS to auto
+* [`Pull Request 624`](https://github.com/navcoin/navcoin-core/pull/624) [`Commit 7058550`](https://github.com/navcoin/navcoin-core/commit/7058550da5fe3a2f6ad5493fab763cea285f1a05) Updates to make the wallet.py and stakeimmaturebalance.py test more reliable
+* [`Pull Request 636`](https://github.com/navcoin/navcoin-core/pull/636) [`Commit e6f3c23`](https://github.com/navcoin/navcoin-core/commit/e6f3c23f41d5a3a4228f95bd9d67c6acff81f1a3) Only count stakes in main chain
+* [`Pull Request 633`](https://github.com/navcoin/navcoin-core/pull/633) [`Commit bfe9071`](https://github.com/navcoin/navcoin-core/commit/bfe90717910cfaa49562efdb14259deb6b208dac) Add second dns seeder
+* [`Pull Request 622`](https://github.com/navcoin/navcoin-core/pull/622) [`Commit 37fa72e`](https://github.com/navcoin/navcoin-core/commit/37fa72e386ad3daff58b92ed7dda1a9b0676a43b) CFundDB extra log and ensure read before modify
+* [`Pull Request 628`](https://github.com/navcoin/navcoin-core/pull/628) [`Commit b8ed018`](https://github.com/navcoin/navcoin-core/commit/b8ed0180a2deaf616c8e6b38aec42385f0a73879) Restart testnet
+* [`Pull Request 623`](https://github.com/navcoin/navcoin-core/pull/623) [`Commit 09ea936`](https://github.com/navcoin/navcoin-core/commit/09ea936f9bd1bb6557d541344345889252d6aef9) Disable CFund client functionality
+* [`Pull Request 609`](https://github.com/navcoin/navcoin-core/pull/609) [`Commit 1e73c05`](https://github.com/navcoin/navcoin-core/commit/1e73c05b17bc812057a866b414d66573211ad755) Added clearer error messages for the nRequest amount validation
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/4.7.2) release tag on GitHub.
+
+To download the NavCoin Core 4.7.2 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.es.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.es.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.it.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.it.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.jp.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.jp.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.kr.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.kr.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.ru.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.ru.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.zh.md
+++ b/content/notices/2020-02-9-navcoin-core-4-7-3-header-spam-protection-improvements.zh.md
@@ -1,0 +1,50 @@
+---
+layout: notices
+title: NavCoin Core 4.7.3 - Header Spam Protection Improvements
+author: Craig MacGregor
+date: '2020-02-09T09:00:00+13:00'
+feature_image: /images/uploads/navcoin-core-4.7.3.png
+notice_categories:
+  - General Notices
+---
+This release only features one merged pull request, but it is an important security patch. It is recommended for all stakers and economic nodes to update immediately to ensure network stability. Everyone else running NavCoin Core is recommended to upgrade as soon as possible, even if you're not staking.
+<!--more-->
+## Anti Header Spam v2
+
+<[Pull Request 656](https://github.com/navcoin/navcoin-core/pull/656)>
+<[Commit 5f11875](https://github.com/navcoin/navcoin-core/commit/5f118753a1900241e9cf8ea38281e4fe75cfeae8)>
+
+
+Introduces a new anti header spam system which improves the previous implementation and addresses the art-of-bug reports.
+
+Features:
+
+- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
+- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
+- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
+- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
+- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
+- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
+- When `-debug=bench` is specified, execution time for the `updateState` function is logged.
+
+#### Considerations
+
+- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
+
+- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
+
+```c++
+    CBlockIndex* pindex = new CBlockIndex();
+    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
+    ss << CDiskBlockIndex(pindex);
+    std::vector<unsigned char>vch(ss.begin(), ss.end());
+    std::cout << to_string(vch.size()) << std::endl;
+```
+
+- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.
+
+### More Information
+
+For the full release notes please visit the [Header Spam Protection Improvements](https://github.com/navcoin/navcoin-core/releases/tag/4.7.3) release tag on GitHub.
+
+To download the NavCoin Core 4.7.3 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.es.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.es.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.it.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.it.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.jp.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.jp.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.kr.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.kr.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.ru.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.ru.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.zh.md
+++ b/content/notices/2020-05-28-navcoin-core-5-0-0-dao-extension.zh.md
@@ -1,0 +1,61 @@
+---
+layout: notices
+title: NavCoin Core 5.0.0 - DAO Extension
+author: Craig MacGregor
+date: '2020-05-28T16:17:48+12:00'
+feature_image: /images/uploads/navcoin-core-5.0.0-dao-extension.png
+notice_categories:
+  - General Notices
+---
+This major release includes multiple soft forks which will extend the NavCoin DAO and enable the community to not only vote on the allocation of the decentralised fund, but also vote on the network consensus parameters changes as well as a non binding onchain voting mechanism called consultations.
+<!--more-->
+
+By downloading and installing this new version of software you will be automatically voting "yes" for the included soft forks. To vote "no" you can set `rejectversionbit=X` in your config file, replacing `X` with the version bit number you wish to reject.
+
+Once a soft fork reaches consensus, it will be activated on the network 1 period after being accepted at which point everyone running navcoin core whether you're mining or not, will need to upgrade to this version.
+
+You can keep track of the soft fork voting progress on the block explorer.
+
+https://www.navexplorer.com/soft-forks
+
+On top of the DAO Extensions, there are some interesting upgrades including Dandelion++ which is one of the components of NavCoin's new privacy protocol [BLS Confidential Transactions](https://medium.com/@NAVCoin/who-will-watch-the-watchmen-why-privacy-matters-to-navcoin-and-why-we-are-bringing-it-back-e4c8f2cd2cc3).
+
+For more info, check out the release notes below;
+
+### DAO Extension
+
+<[Pull Request 530](https://github.com/navcoin/navcoin-core/pull/530)>
+
+This PR includes a series of Deployment Proposals as described in https://www.reddit.com/r/NavCoin/comments/bs4pvn/proposal_for_the_extension_of_the_community_fund/:
+
+- Adds support for abstaining in the votings. (Version Bit 19) - includes functional test
+
+- Enables voting state cache, reducing the amount of votes which need to be broadcasted down to 1 per address. (Version Bit 22) - does not include specific functional test, but old fund tests pass having this deployment activated
+
+- Enables DAO consultations. (Version Bit 23) - includes functional test
+
+- Enables modification of consensus parameters through DAO consultations. (Version Bit 25) - includes functional test
+
+- Enables voting delegation and voting from light wallets. (Version bit 27) - includes functional test
+
+- Allows fund proposals to have a different address for signing the payment requests and for receiving the payment. This allows to use arbitrary scripts as payment addresses, like multisig addresses. When the payment address differs from the owner address, the first will be specified using the p parameter on the JSON object embedded on the strDZeel property of the transaction.
+
+- Includes UI to manage the new DAO features.
+
+### Dandelion++
+
+<[Pull Request 588](https://github.com/navcoin/navcoin-core/pull/588)>
+
+This PR adds support for Dandelion as described in https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki
+
+### Mnemonic startup GUI
+
+<[Pull Request 659](https://github.com/navcoin/navcoin-core/pull/659)>
+
+This PR adds a Startup GUI which allows for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.
+
+### More Information
+
+For the full release notes please visit the [Community Fund Stability Patches](https://github.com/navcoin/navcoin-core/releases/tag/5.0.0) release tag on GitHub.
+
+To download the NavCoin Core 5.0.0 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.es.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.es.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.it.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.it.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.jp.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.jp.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.kr.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.kr.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.ru.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.ru.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.

--- a/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.zh.md
+++ b/content/notices/2020-06-09-navcoin-core-5-0-1-hotfixes.zh.md
@@ -1,0 +1,57 @@
+---
+layout: notices
+title: NavCoin Core 5.0.1 - Hotfixes
+author: alex v
+date: '2020-06-09T10:52:33+01:00'
+feature_image: /images/uploads/navcoin-core-5.0.1-hotfixes.png
+notice_categories:
+  - General Notices
+---
+This minor release contains a small set of patches for our last major release. Upgrade is not mandatory but recommended, specially if you use the mnemonic backup feature.
+<!--more-->
+
+# NavCoin v5.0.1 Release Notes
+
+### Fix getaddressbalance for address reuse
+
+<[Pull Request 691](https://github.com/navcoin/navcoin-core/pull/691)>
+
+### Updated the message that RPC call returns after encrypting wallet
+
+<[Pull Request 708](https://github.com/navcoin/navcoin-core/pull/708)>
+
+### Added more progress indicators during wallet start up
+
+<[Pull Request 702](https://github.com/navcoin/navcoin-core/pull/702)>
+
+### Added a password step to setup wizard 
+
+<[Pull Request 700](https://github.com/navcoin/navcoin-core/pull/700)>
+
+### Fix for crash when voting for payment request 
+
+<[Pull Request 706](https://github.com/navcoin/navcoin-core/pull/706)>
+
+### Added new show/dump mnemonic UI, similar to the dumpmnemonic RPC call
+
+<[Pull Request 692](https://github.com/navcoin/navcoin-core/pull/692)>
+
+### Fixed qa/rpc-tests/dao-consultation-consensus.py
+
+<[Pull Request 703](https://github.com/navcoin/navcoin-core/pull/703)>
+
+### Updated the encrypt wallet logic to not replace master key
+
+<[Pull Request 697](https://github.com/navcoin/navcoin-core/pull/697)>
+
+### Fixed some functional tests that were checking for state == 0 for expired proposals or prequests
+
+<[Pull Request 698](https://github.com/navcoin/navcoin-core/pull/698)>
+
+### Updated price update timer to respect shutdown request
+
+<[Pull Request 696](https://github.com/navcoin/navcoin-core/pull/696)>
+
+For additional information about new features, check [https://navcoin.org/en/notices/](https://navcoin.org/en/notices/) 
+
+To download the NavCoin Core 5.0.1 please visit the [Wallet Downloads](https://navcoin.org/en/wallets/#download-core) page.


### PR DESCRIPTION
Language files in notices had stopped at 4.6.0. The added files have not been translated yet, but will fill the news gap as an interim.

resolves #286

https://deploy-preview-287--navcoin.netlify.com/en/notices
https://deploy-preview-287--navcoin.netlify.com/es/notices
https://deploy-preview-287--navcoin.netlify.com/zh/notices
https://deploy-preview-287--navcoin.netlify.com/jp/notices
https://deploy-preview-287--navcoin.netlify.com/it/notices
https://deploy-preview-287--navcoin.netlify.com/kr/notices
https://deploy-preview-287--navcoin.netlify.com/ru/notices

