### PR TITLE
Issue #309

### DIFF
--- a/content/buy-navcoin/index.jp.md
+++ b/content/buy-navcoin/index.jp.md
@@ -32,12 +32,6 @@ newTab="true"
         linkUrl="https://www.binance.com/en/trade/NAV_BTC"
     >}}
     {{< exchange
-        titleText="Litebit"
-        imgSrc="/images/buy-navcoin/buy-litebit.png"
-        text="ユーロによる直接購入"
-        linkUrl="https://www.litebit.eu/en/buy/navcoin"
-    >}}
-    {{< exchange
         titleText="Easy Crypto"
         imgSrc="/images/buy-navcoin/buy-easy-crypto.png"
         text="NZDによる直接購入"
@@ -66,12 +60,6 @@ newTab="true"
         imgSrc="/images/buy-navcoin/buy-crex-24.png"
         text="複数取引所プラットフォーム"
         linkUrl="https://crex24.com/exchange/NAV-BTC"
-    >}}
-    {{< exchange
-        titleText="Bitexlive"
-        imgSrc="/images/buy-navcoin/bitexlive.png"
-        text="BTC / NAV"
-        linkUrl="https://bitexlive.com/exchange/BTC-NAV"
     >}}
     {{< exchange
         titleText="Coinmerce"


### PR DESCRIPTION
Description

    Litebit delists Navcoin. Should be removed there asap.
    Bitexlive is linked twice. Please remove one.

Motivation
Having uptodate and correct overview where NAV can be bought/traded.

Thanks.