### PR TITLE
Issue #309

### DIFF
--- a/content/buy-navcoin/index.it.md
+++ b/content/buy-navcoin/index.it.md
@@ -32,12 +32,6 @@ newTab="true"
         linkUrl="https://www.binance.com/it/trade/NAV_BTC"
     >}}
     {{< exchange
-        titleText="Litebit"
-        imgSrc="/images/buy-navcoin/buy-litebit.png"
-        text="Euro acquisto diretto"
-        linkUrl="https://www.litebit.eu/en/buy/navcoin"
-    >}}
-    {{< exchange
         titleText="Easy Crypto"
         imgSrc="/images/buy-navcoin/buy-easy-crypto.png"
         text="Acquisto diretto NZD"
@@ -66,12 +60,6 @@ newTab="true"
         imgSrc="/images/buy-navcoin/buy-crex-24.png"
         text="Multi piattaforma di scambio"
         linkUrl="https://crex24.com/exchange/NAV-BTC"
-    >}}
-    {{< exchange
-        titleText="Bitexlive"
-        imgSrc="/images/buy-navcoin/bitexlive.png"
-        text="BTC / NAV"
-        linkUrl="https://bitexlive.com/exchange/BTC-NAV"
     >}}
     {{< exchange
         titleText="Coinmerce"


### PR DESCRIPTION
Description

    Litebit delists Navcoin. Should be removed there asap.
    Bitexlive is linked twice. Please remove one.

Motivation
Having uptodate and correct overview where NAV can be bought/traded.

Thanks.