### PR TITLE
Issue #309

### DIFF
--- a/content/buy-navcoin/index.ru.md
+++ b/content/buy-navcoin/index.ru.md
@@ -32,12 +32,6 @@ newTab="подлинный"
         linkUrl="https://www.binance.com/ru/trade/NAV_BTC"
     >}}
     {{< exchange
-        titleText="Litebit"
-        imgSrc="/images/buy-navcoin/buy-litebit.png"
-        text="Прямая покупка Евро"
-        linkUrl="https://www.litebit.eu/en/buy/navcoin"
-    >}}
-    {{< exchange
         titleText="Easy Crypto"
         imgSrc="/images/buy-navcoin/buy-easy-crypto.png"
         text="Прямая покупка NZD"
@@ -66,12 +60,6 @@ newTab="подлинный"
         imgSrc="/images/buy-navcoin/buy-crex-24.png"
         text="Мультивалютная биржа"
         linkUrl="https://crex24.com/exchange/NAV-BTC"
-    >}}
-    {{< exchange
-        titleText="Bitexlive"
-        imgSrc="/images/buy-navcoin/bitexlive.png"
-        text="BTC / NAV"
-        linkUrl="https://bitexlive.com/exchange/BTC-NAV"
     >}}
     {{< exchange
         titleText="Coinmerce"


### PR DESCRIPTION
Description

    Litebit delists Navcoin. Should be removed there asap.
    Bitexlive is linked twice. Please remove one.

Motivation
Having uptodate and correct overview where NAV can be bought/traded.

Thanks.