### PR TITLE
Add redirect from /en

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -92,3 +92,8 @@ command = "hugo"
   status = 301
   force = true
 
+[[redirects]]
+  from = "/en"
+  to = "/"
+  status = 301
+  force = true


### PR DESCRIPTION
### Description

Add redirect from `/en` if accessed by the url of the previous site.

### Approach

Updated `netlify.toml` to include a `301` redirect from `/en` to `/`.

### Preview Links

[Link to preview](https://deploy-preview-334--navcoin.netlify.app).

### Checklist

- [ ] Have you assigned/claimed the issues you've resolved in this pull request?
- [ ] Have the issues been moved to the QA column of the Navcoin Websites project? 
- [ ] Have you checked there are no merge conflicts?
- [ ] Have you tested the changes work across both mobile and desktop?