### PR TITLE
Updated links to exchanges to the direct URL for the NAV pair where possible

### DIFF
--- a/static/data/exchanges.json
+++ b/static/data/exchanges.json
@@ -14,13 +14,13 @@
   {
     "name": "SouthXchange",
     "description": "No KYC required",
-    "url": "https://main.southxchange.com",
+    "url": "https://main.southxchange.com/Market/Book/NAV/BTC",
     "imageURL": "images/southxchange-logo.svg"
   },
   {
     "name": "Bisq",
     "description": "No KYC required",
-    "url": "https://bisq.network",
+    "url": "https://bisq.markets/market/nav_btc",
     "imageURL": "images/bisq-logo.svg"
   },
   {
@@ -32,7 +32,7 @@
   {
     "name": "Bitexlive",
     "description": "No KYC required",
-    "url": "https://bitexlive.com",
+    "url": "https://bitexlive.com/exchange/BTC-NAV",
     "imageURL": "images/bitexlive-logo.svg"
   },
   {
@@ -44,7 +44,7 @@
   {
     "name": "7b",
     "description": "No KYC required",
-    "url": "https://sevenb.io",
+    "url": "https://sevenb.io/currencies/nav-coin",
     "imageURL": "images/7b-logo.svg"
   },
   {
@@ -128,19 +128,19 @@
   {
     "name": "Binance",
     "description": "Requires KYC",
-    "url": "https://binance.com",
+    "url": "https://www.binance.com/en/trade/NAV_BTC",
     "imageURL": "images/binance-logo.svg"
   },
   {
     "name": "Bittrex",
     "description": "Requires KYC",
-    "url": "https://bittrex.com",
+    "url": "https://global.bittrex.com/Market/Index?MarketName=BTC-NAV",
     "imageURL": "images/bittrex-small-logo.png"
   },
   {
     "name": "HitBTC",
     "description": "Requires KYC",
-    "url": "https://hitbtc.com",
+    "url": "https://hitbtc.com/nav-to-btc",
     "imageURL": "images/hitbtc-logo.jpg"
   },
   {
@@ -158,19 +158,19 @@
   {
     "name": "BitPrime",
     "description": "Requires KYC",
-    "url": "https://www.bitprime.co.nz",
+    "url": "https://www.bitprime.co.nz/product/navcoin-nav/",
     "imageURL": "images/bitprime-logo.png"
   },
   {
     "name": "Crex24",
     "description": "Requires KYC",
-    "url": "https://crex24.com",
+    "url": "https://crex24.com/de/exchange/NAV-BTC",
     "imageURL": "images/crex24-logo.svg"
   },
   {
     "name": "Coinmerce",
     "description": "Requires KYC",
-    "url": "https://coinmerce.io",
+    "url": "https://coinmerce.io/en/navcoin/",
     "imageURL": "images/coinmerce-logo.png"
   },
   {


### PR DESCRIPTION
### Description

I've changed the URLs of the exchanges to point to directly point to the page where one can trade NAV.

### Issues Resolved

none

### Preview Links

Paste the preview links where the changes can be viewed on the netlify deploy preview (you'll need to add these after the PR is made and the preview is deployed).

eg. https://deploy-preview-205--navcoin.netlify.com/en/buy-navcoin

The preview can be found on the pull request once it's made by clicking `show all checks` > `details`.

### Checklist

- [x] Have you assigned/claimed the issues you've resolved in this pull request?
- [x] Have the issues been moved to the QA column of the Navcoin Websites project?
- [x] Have you checked there are no merge conflicts?
- [x] Have you tested the changes work across both mobile and desktop?
