### PR TITLE
Updated OSX download to link to 7.0.1 DMG while we fix the issue with 7.0.3 build

### DIFF
--- a/content/get-started.html
+++ b/content/get-started.html
@@ -140,9 +140,9 @@
           <div class="platform-content">
             <div class="center-aligned-flex"><img src="/images/apple-logo.svg" loading="lazy" height="40" alt=""></div>
             <h3 class="platform-title">macOS<br></h3>
-            <p class="platform-paragraph">Version 7.0.3</p>
+            <p class="platform-paragraph">Version 7.0.1</p>
             <div class="center-aligned-flex">
-              <a href="https://github.com/navcoin/navcoin-core/releases/download/7.0.3/navcoin-7.0.3-osx.dmg" class="small-light-background-button w-button">Download</a>
+              <a href="https://github.com/navcoin/navcoin-core/releases/download/7.0.1/navcoin-7.0.1-osx-signed.dmg" class="small-light-background-button w-button">Download</a>
             </div>
           </div>
           <div class="platform-content">


### PR DESCRIPTION
### Description

Updated the OSX download link to use 7.0.1 while we solve OSX build signing for newer version

### Preview Links

https://deploy-preview-365--navcoin.netlify.app/get-started
