### PR TITLE
Center exchange images get-started page

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2060,7 +2060,9 @@ figcaption {
 }
 
 .get-started-exchange-content {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   height: 100%;
   padding: 10px;


### PR DESCRIPTION
### Description

Center exchange images get-started page

### Preview Links

[https://deploy-preview-367--cranky-visvesvaraya-877402.netlify.app/get-started](https://deploy-preview-367--cranky-visvesvaraya-877402.netlify.app/get-started)

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/24814046/190491456-d02865fd-d554-461f-982b-465fecde77e5.png">


### Checklist

- [ ] Have you assigned/claimed the issues you've resolved in this pull request?
- [ ] Have the issues been moved to the QA column of the Navcoin Websites project?
- [ ] Have you checked there are no merge conflicts?
- [ ] Have you tested the changes work across both mobile and desktop?
